### PR TITLE
Persist OIDC tokens in the security token

### DIFF
--- a/src/OidcTokens.php
+++ b/src/OidcTokens.php
@@ -20,9 +20,24 @@ class OidcTokens
   private $accessToken;
 
   /**
+   * @var \DateTime
+   */
+  private $expiry;
+
+  /**
    * @var string
    */
   private $idToken;
+
+  /**
+   * @var string
+   */
+  private $refreshToken;
+
+  /**
+   * @var string[]
+   */
+  private $scope;
 
   /**
    * OidcTokens constructor.
@@ -33,11 +48,18 @@ class OidcTokens
    */
   public function __construct(stdClass $tokens)
   {
-    if (!isset($tokens->id_token) || !isset($tokens->access_token)) {
-      throw new OidcException("Invalid token object.");
+    if (!isset($tokens->id_token) || !isset($tokens->access_token) || !isset($tokens->expires_in)) {
+      throw new OidcException('Invalid token object.');
     }
-    $this->accessToken = $tokens->access_token;
-    $this->idToken     = $tokens->id_token;
+
+    $expiry = \DateTime::createFromFormat('U', (string) time() + $tokens->expires_in);
+    assert($expiry instanceof \DateTime);
+
+    $this->accessToken  = $tokens->access_token;
+    $this->idToken      = $tokens->id_token;
+    $this->expiry       = $expiry;
+    $this->refreshToken = $tokens->refresh_token;
+    $this->scope        = explode(' ', $tokens->scope);
   }
 
   /**
@@ -48,11 +70,23 @@ class OidcTokens
     return $this->accessToken;
   }
 
-  /**
-   * @return string
-   */
+  public function getExpiry(): \DateTime
+  {
+    return $this->expiry;
+  }
+
   public function getIdToken(): string
   {
     return $this->idToken;
+  }
+
+  public function getRefreshToken(): string
+  {
+    return $this->refreshToken;
+  }
+
+  public function getScope(): array
+  {
+    return $this->scope;
   }
 }

--- a/src/Security/Authentication/Provider/OidcProvider.php
+++ b/src/Security/Authentication/Provider/OidcProvider.php
@@ -80,8 +80,11 @@ class OidcProvider implements AuthenticationProviderInterface
     $this->userChecker->checkPostAuth($user);
 
     // Create the authenticated token
+    $authData = $token->getAuthData();
     $token = new OidcToken($user->getRoles());
-    $token->setUser($user);
+    $token
+      ->setAuthData($authData)
+      ->setUser($user);
 
     return $token;
   }

--- a/src/Security/Authentication/Token/OidcToken.php
+++ b/src/Security/Authentication/Token/OidcToken.php
@@ -2,6 +2,7 @@
 
 namespace Drenso\OidcBundle\Security\Authentication\Token;
 
+use Drenso\OidcBundle\OidcTokens;
 use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
 
 class OidcToken extends AbstractToken
@@ -151,13 +152,25 @@ class OidcToken extends AbstractToken
   /**
    * Set the user data from the OIDC response
    *
-   * @param $userData
+   * @param array $userData
    *
    * @return OidcToken
    */
-  public function setUserData(array $userData)
+  public function setUserData(array $userData): self
   {
     $this->userData = $userData;
+
+    return $this;
+  }
+
+  /**
+   * Set the auth data from the OIDC response.
+   *
+   * @return OidcToken
+   */
+  public function setAuthData(OidcTokens $authData): self
+  {
+    $this->setAttribute('authData', $authData);
 
     return $this;
   }
@@ -210,5 +223,13 @@ class OidcToken extends AbstractToken
     }
 
     return NULL;
+  }
+
+  /**
+   * Get auth data - OIDC tokens, scope and expiry.
+   */
+  public function getAuthData(): OidcTokens
+  {
+    return $this->getAttribute('authData');
   }
 }

--- a/src/Security/Firewall/OidcListener.php
+++ b/src/Security/Firewall/OidcListener.php
@@ -85,7 +85,9 @@ class OidcListener extends AbstractAuthenticationListener
 
       // Create token
       $token = new OidcToken();
-      $token->setUserData($userData);
+      $token
+        ->setUserData($userData)
+        ->setAuthData($authData);
 
       // Try to authenticate this against the Symfony authentication backend
       return $this->authenticationManager->authenticate($token);


### PR DESCRIPTION
Hello again!

This PR persists the OIDC tokens into the token, along with the scopes and expiry.

We need the id_token for our logout:
```php
    /**
     * @Route("/logout", name="oidc_logout")
     */
    public function logout(TokenStorageInterface $tokenStorageInterface): RedirectResponse
    {
        $token = $tokenStorageInterface->getToken();
        if ($token instanceof AnonymousToken) {
            return $this->redirect('/');
        }
        assert($token instanceof OidcToken);

        // clear the security token to logout locally
        $tokenStorageInterface->setToken(null);

        // generate OIDC logout redirect
        $query = http_build_query([
            'post_logout_redirect_uri' => $this->generateUrl('dbla_cms_default', [], UrlGenerator::ABSOLUTE_URL),
            'id_token_hint' => $token->getAuthData()->getIdToken(),
        ]);
        $oidcUri = $this->getParameter('auth_site.oidc_base_uri');
        $redirect = "$oidcUri/connect/session/end?$query";

        return $this->redirect($redirect);
    }
```

In the future this can also be used to handle token refresh. I was thinking something along the lines of:

- add a helper function into this library to do a server-side refresh token request
- check the access_token expiry in OidcUserProviderInterface::refreshUser() and call the helper

Otherwise it might be better to do it from the security listener or provider or something - it's not really clear how best to do this from the symfony docs.