### PR TITLE
Provided provision to pass custom headers to curl fetcher calls

### DIFF
--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -66,6 +66,13 @@ class OidcClient
    * @var string
    */
   private $clientSecret;
+
+  /**
+   * OIDC Custom headers
+   * @var string
+   */
+  private $customHeaders;
+
   /**
    * @var string|null
    */
@@ -79,11 +86,12 @@ class OidcClient
    * @param string           $wellKnownUrl
    * @param string           $clientId
    * @param string           $clientSecret
+   * @param string           $customHeaders
    * @param string|null      $redirectRoute
    */
   public function __construct(
       SessionInterface $session, RouterInterface $router, string $wellKnownUrl, string $clientId, string $clientSecret,
-      ?string $redirectRoute = 'login_check')
+      ?string $redirectRoute = 'login_check', ?string $customHeaders = '')
   {
     // Check for required phpseclib classes
     if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('\phpseclib3\Crypt\RSA')) {
@@ -95,9 +103,10 @@ class OidcClient
     $this->wellKnownUrl  = $wellKnownUrl;
     $this->clientId      = $clientId;
     $this->clientSecret  = $clientSecret;
+    $this->customHeaders =  $customHeaders;
     $this->redirectRoute = $redirectRoute;
 
-    $this->urlFetcher = new OidcUrlFetcher();
+    $this->urlFetcher = new OidcUrlFetcher($this->customHeaders);
     $this->jwtHelper  = new OidcJwtHelper($this->session, $this->urlFetcher, $clientId);
   }
 

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -80,8 +80,8 @@ class OidcClient
    * @param string           $wellKnownUrl
    * @param string           $clientId
    * @param string           $clientSecret
-   * @param string           $customHeaders
    * @param string|null      $redirectRoute
+   * @param string[]         $customHeaders
    */
   public function __construct(
       SessionInterface $session, RouterInterface $router, string $wellKnownUrl, string $clientId, string $clientSecret,

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -68,12 +68,6 @@ class OidcClient
   private $clientSecret;
 
   /**
-   * OIDC Custom headers
-   * @var string
-   */
-  private $customHeaders;
-
-  /**
    * @var string|null
    */
   private $redirectRoute;
@@ -91,7 +85,7 @@ class OidcClient
    */
   public function __construct(
       SessionInterface $session, RouterInterface $router, string $wellKnownUrl, string $clientId, string $clientSecret,
-      ?string $redirectRoute = 'login_check', ?string $customHeaders = '')
+      ?string $redirectRoute = 'login_check', array $customHeaders = [])
   {
     // Check for required phpseclib classes
     if (!class_exists('\phpseclib\Crypt\RSA') && !class_exists('\phpseclib3\Crypt\RSA')) {
@@ -103,10 +97,9 @@ class OidcClient
     $this->wellKnownUrl  = $wellKnownUrl;
     $this->clientId      = $clientId;
     $this->clientSecret  = $clientSecret;
-    $this->customHeaders =  $customHeaders;
     $this->redirectRoute = $redirectRoute;
 
-    $this->urlFetcher = new OidcUrlFetcher($this->customHeaders);
+    $this->urlFetcher = new OidcUrlFetcher($customHeaders);
     $this->jwtHelper  = new OidcJwtHelper($this->session, $this->urlFetcher, $clientId);
   }
 

--- a/src/OidcUrlFetcher.php
+++ b/src/OidcUrlFetcher.php
@@ -12,6 +12,23 @@ use Drenso\OidcBundle\Security\Exception\OidcAuthenticationException;
  */
 class OidcUrlFetcher
 {
+    
+  /**
+   * @var string
+   */
+  private $customHeaders;
+  
+  /**
+   * OidcUrlFetcher constructor.
+   *
+   * @param string           $customHeaders
+   */
+  public function __construct(?string $customHeaders='')
+  {   
+    $this->customHeaders   = $customHeaders;
+    
+     
+  }
   /**
    * Retrieve the content from the specified url
    *
@@ -48,6 +65,12 @@ class OidcUrlFetcher
     // Add a User-Agent header to prevent firewall blocks
     $curlVersion = curl_version()['version'];
     $headers[] = "User-Agent: curl/$curlVersion drenso/symfony-oidc";
+    
+    //Add additional headers to Headers
+    if(!empty($this->customHeaders)){
+        $customHeaderArray = explode(';', $this->customHeaders);
+        $headers = array_merge($headers,$customHeaderArray);
+    }
 
     // Include headers
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);

--- a/src/OidcUrlFetcher.php
+++ b/src/OidcUrlFetcher.php
@@ -14,16 +14,16 @@ class OidcUrlFetcher
 {
     
   /**
-   * @var string
+   * @var array
    */
   private $customHeaders;
   
   /**
    * OidcUrlFetcher constructor.
    *
-   * @param string           $customHeaders
+   * @param array           $customHeaders
    */
-  public function __construct(?string $customHeaders='')
+  public function __construct(array $customHeaders = [])
   {   
     $this->customHeaders   = $customHeaders;
     
@@ -66,10 +66,9 @@ class OidcUrlFetcher
     $curlVersion = curl_version()['version'];
     $headers[] = "User-Agent: curl/$curlVersion drenso/symfony-oidc";
     
-    //Add additional headers to Headers
-    if(!empty($this->customHeaders)){
-        $customHeaderArray = explode(';', $this->customHeaders);
-        $headers = array_merge($headers,$customHeaderArray);
+    // Add custom headers to a existing headers
+    if(!empty($this->customHeaders) && is_array($this->customHeaders)){        
+        $headers = array_merge($headers,$this->customHeaders);        
     }
 
     // Include headers

--- a/src/OidcUrlFetcher.php
+++ b/src/OidcUrlFetcher.php
@@ -21,14 +21,13 @@ class OidcUrlFetcher
   /**
    * OidcUrlFetcher constructor.
    *
-   * @param array           $customHeaders
+   * @param string[] $customHeaders
    */
   public function __construct(array $customHeaders = [])
   {   
     $this->customHeaders   = $customHeaders;
-    
-     
   }
+
   /**
    * Retrieve the content from the specified url
    *

--- a/src/OidcUrlFetcher.php
+++ b/src/OidcUrlFetcher.php
@@ -66,9 +66,7 @@ class OidcUrlFetcher
     $headers[] = "User-Agent: curl/$curlVersion drenso/symfony-oidc";
     
     // Add custom headers to a existing headers
-    if(!empty($this->customHeaders) && is_array($this->customHeaders)){        
-        $headers = array_merge($headers,$this->customHeaders);        
-    }
+    $headers = array_merge($headers, $this->customHeaders);
 
     // Include headers
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);


### PR DESCRIPTION
1. Introduce new variable to ENV to accept the custom headers separated by semicolon(;)
    ex: OIDC_CUSTOM_HEADERS=customheaderKey1:customHeaderValue1;customheaderKey2:customHeaderValue2
2. Make following changes under /config/services.yaml file to pass custom headers to oidcClient.
    2.1 oidc.custom_headers: '%env(OIDC_CUSTOM_HEADERS)%'
    2.2 Drenso\OidcBundle\OidcClient:
      	   arguments: 
		$customHeaders: '%oidc.custom_headers%' 