### PR TITLE
feat: implement support for end_session_endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ There are a couple of options available for the `oidc` listener.
 | `client`                         | `default`       | The configured OIDC client to use                                                                                                             |
 | `user_identifier_property`       | `sub`           | The OidcUserData property to use as unique user identifier                                                                                    |
 | `enable_remember_me`             | `false`         | Enable "remember me" functionality for authenticator                                                                                          |
+| `enable_end_session_listener`    | `false`         | Enable "logout" functionality for authenticator through the "LogoutEvent"                                                                     |
+| `use_logout_target_path`         | `true`          | Used for the end session event subscriber                                                                                                     |
 | `always_use_default_target_path` | `false`         | Used for the success handler                                                                                                                  |
 | `default_target_path`            | `/`             | Used for the success handler                                                                                                                  |
 | `target_path_parameter`          | `_target_path`  | Used for the success handler                                                                                                                  |
@@ -170,6 +172,52 @@ You can override the `_remember_me` parameter per OIDC client. Just update the `
 Lastly, make sure the Symfony remember me authenticator is enabled, and that you set the `enable_remember_me` option to true for the `oidc` authenticator in `security.yaml`.
 
 When a user is authenticated, you will see the `REMEMBERME` cookie. You can remove the `PHPSESSID` cookie to check whether remember me is working.
+
+### Logout
+
+It is possible to enable "logout" through the `end_session_support` functionality of the Identity Provider, if the `end_session_endpoint` parameter is present in the .well-known endpoint it can be used. 
+
+Because logging out is not fully functional through OpenID because of the connected providers (for example: Azure, Facebook, etc) possibly not login the user out, this option is disabled by default.
+
+If you want to enable the "logout" support, simply add `enable_end_session_listener: true` to your oidc listener in the firewall config. It will only work of you enabled the default Symfony `logout: true` setting in your firewall.
+
+By default, the listener will pass the logout `target_path` to the OpenID Provider, so the user gets redirected back to your application after login out. If you don't want this and want the user to remain at the logout confirmation page of your OpenID Provider, enable the `use_logout_target_path: false` setting.
+
+**Example: default logout path**
+
+```yaml
+security:
+  firewalls:
+    main:
+      logout: true
+      oidc:
+        enable_end_session_listener: true
+```
+
+**Example: custom logout path**
+
+```yaml
+security:
+  firewalls:
+    main:
+      logout:
+        target: /my_custom_target_path
+      oidc:
+        enable_end_session_listener: true
+```
+**Example: disable redirect to logout `target_path`**
+
+This will keep the user at the OpenID provider after login out.
+```yaml
+security:
+  firewalls:
+    main:
+      logout: true
+      oidc:
+        enable_end_session_listener: true
+        use_logout_target_path: false
+```
+
 
 ### Client locator
 

--- a/README.md
+++ b/README.md
@@ -177,13 +177,13 @@ When a user is authenticated, you will see the `REMEMBERME` cookie. You can remo
 
 It is possible to enable "logout" through the `end_session_support` functionality of the Identity Provider, if the `end_session_endpoint` parameter is present in the .well-known endpoint it can be used. 
 
-Because logging out is not fully functional through OpenID because of the connected providers (for example: Azure, Facebook, etc) possibly not login the user out, this option is disabled by default.
+As logging out is fundamentally broken when using single sign-on, this option is disabled by default. This is due to the fact that logging out at the identity provider (for example: Azure, Facebook, etc) cannot guarantee the user is logged out of any other service that the user has authenticated with using the same identity provider.
 
 If you want to enable the "logout" support, simply add `enable_end_session_listener: true` to your oidc listener in the firewall config. It will only work of you enabled the default Symfony `logout: true` setting in your firewall.
 
-By default, the listener will pass the logout `target_path` to the OpenID Provider, so the user gets redirected back to your application after login out. If you don't want this and want the user to remain at the logout confirmation page of your OpenID Provider, enable the `use_logout_target_path: false` setting.
+By default, the listener will pass the logout `target_path` to the OpenID Provider, so the user gets redirected back to your application after logging out. If you don't want this and want the user to remain at the logout confirmation page of your OpenID Provider, enable the `use_logout_target_path: false` setting.
 
-**Example: default logout path**
+**_Example: default logout path_**
 
 ```yaml
 security:
@@ -194,7 +194,7 @@ security:
         enable_end_session_listener: true
 ```
 
-**Example: custom logout path**
+**_Example: custom logout path_**
 
 ```yaml
 security:
@@ -205,7 +205,8 @@ security:
       oidc:
         enable_end_session_listener: true
 ```
-**Example: disable redirect to logout `target_path`**
+
+**_Example: disable redirect to logout `target_path`_**
 
 This will keep the user at the OpenID provider after login out.
 ```yaml

--- a/src/DependencyInjection/DrensoOidcExtension.php
+++ b/src/DependencyInjection/DrensoOidcExtension.php
@@ -13,13 +13,14 @@ use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 
 class DrensoOidcExtension extends ConfigurableExtension
 {
-  public const BASE_ID            = 'drenso.oidc.';
-  public const AUTHENTICATOR_ID   = self::BASE_ID . 'authenticator';
-  public const URL_FETCHER_ID     = self::BASE_ID . 'url_fetcher';
-  public const JWT_HELPER_ID      = self::BASE_ID . 'jwt_helper';
-  public const SESSION_STORAGE_ID = self::BASE_ID . 'session_storage';
-  public const CLIENT_ID          = self::BASE_ID . 'client';
-  public const CLIENT_LOCATOR_ID  = self::BASE_ID . 'client_locator';
+  public const BASE_ID                  = 'drenso.oidc.';
+  public const AUTHENTICATOR_ID         = self::BASE_ID . 'authenticator';
+  public const URL_FETCHER_ID           = self::BASE_ID . 'url_fetcher';
+  public const JWT_HELPER_ID            = self::BASE_ID . 'jwt_helper';
+  public const SESSION_STORAGE_ID       = self::BASE_ID . 'session_storage';
+  public const CLIENT_ID                = self::BASE_ID . 'client';
+  public const CLIENT_LOCATOR_ID        = self::BASE_ID . 'client_locator';
+  public const END_SESSION_LISTENER_ID  = self::BASE_ID . 'end_session_listener';
 
   public function loadInternal(array $mergedConfig, ContainerBuilder $container): void
   {

--- a/src/EventListener/OidcEndSessionSubscriber.php
+++ b/src/EventListener/OidcEndSessionSubscriber.php
@@ -5,11 +5,9 @@ namespace Drenso\OidcBundle\EventListener;
 use Drenso\OidcBundle\Exception\OidcConfigurationException;
 use Drenso\OidcBundle\Exception\OidcConfigurationResolveException;
 use Drenso\OidcBundle\Exception\OidcException;
-use Drenso\OidcBundle\Model\OidcTokens;
 use Drenso\OidcBundle\OidcClientInterface;
+use Drenso\OidcBundle\Security\Token\OidcToken;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
 use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\HttpUtils;
 
@@ -31,15 +29,11 @@ class OidcEndSessionSubscriber implements EventSubscriberInterface
   {
     $token = $event->getToken();
 
-    if (!$token instanceof TokenInterface) {
-      throw new TokenNotFoundException();
+    if (!$token instanceof OidcToken) {
+      return;
     }
 
-    $oidcTokens = $token->getAttribute('auth_data');
-
-    if (!$oidcTokens instanceof OidcTokens) {
-      throw new OidcException('Invalid token object.');
-    }
+    $oidcTokens = $token->getAuthData();
 
     $postLogoutRedirectUrl = null !== $this->logoutTarget ? $this->httpUtils->generateUri($event->getRequest(), $this->logoutTarget) : null;
 

--- a/src/EventListener/OidcEndSessionSubscriber.php
+++ b/src/EventListener/OidcEndSessionSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Drenso\OidcBundle\EventListener;
+
+use Drenso\OidcBundle\Exception\OidcConfigurationException;
+use Drenso\OidcBundle\Exception\OidcConfigurationResolveException;
+use Drenso\OidcBundle\Exception\OidcException;
+use Drenso\OidcBundle\Model\OidcTokens;
+use Drenso\OidcBundle\OidcClientInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\TokenNotFoundException;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
+use Symfony\Component\Security\Http\HttpUtils;
+
+class OidcEndSessionSubscriber implements EventSubscriberInterface
+{
+  public function __construct(
+     private OidcClientInterface $oidcClient,
+     private HttpUtils $httpUtils,
+     private string $logoutTarget
+  ) {
+  }
+
+  /**
+   * @throws OidcConfigurationException
+   * @throws OidcConfigurationResolveException
+   * @throws OidcException
+   */
+  public function onLogout(LogoutEvent $event): void
+  {
+    $token = $event->getToken();
+
+    if (!$token instanceof TokenInterface) {
+      throw new TokenNotFoundException();
+    }
+
+    $oidcTokens = $token->getAttribute('auth_data');
+
+    if (!$oidcTokens instanceof OidcTokens) {
+      throw new OidcException('Invalid token object.');
+    }
+
+    $postLogoutRedirectUrl = $this->httpUtils->generateUri($event->getRequest(), $this->logoutTarget);
+
+    $event->setResponse($this->oidcClient->generateEndSessionEndpointRedirect($oidcTokens, $postLogoutRedirectUrl));
+  }
+
+  public static function getSubscribedEvents(): array
+  {
+    return [LogoutEvent::class => 'onLogout'];
+  }
+}

--- a/src/EventListener/OidcEndSessionSubscriber.php
+++ b/src/EventListener/OidcEndSessionSubscriber.php
@@ -18,7 +18,7 @@ class OidcEndSessionSubscriber implements EventSubscriberInterface
   public function __construct(
      private OidcClientInterface $oidcClient,
      private HttpUtils $httpUtils,
-     private string $logoutTarget
+     private ?string $logoutTarget = null
   ) {
   }
 
@@ -41,7 +41,7 @@ class OidcEndSessionSubscriber implements EventSubscriberInterface
       throw new OidcException('Invalid token object.');
     }
 
-    $postLogoutRedirectUrl = $this->httpUtils->generateUri($event->getRequest(), $this->logoutTarget);
+    $postLogoutRedirectUrl = null !== $this->logoutTarget ? $this->httpUtils->generateUri($event->getRequest(), $this->logoutTarget) : null;
 
     $event->setResponse($this->oidcClient->generateEndSessionEndpointRedirect($oidcTokens, $postLogoutRedirectUrl));
   }

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -165,7 +165,7 @@ class OidcClient implements OidcClientInterface
   /** {@inheritDoc} */
   public function generateEndSessionEndpointRedirect(
       OidcTokens $tokens,
-      string $postLogoutRedirectUrl = null,
+      ?string $postLogoutRedirectUrl = null,
       array $additionalQueryParams = []
   ): RedirectResponse {
     $data = array_merge($additionalQueryParams, [

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -165,14 +165,19 @@ class OidcClient implements OidcClientInterface
   /** {@inheritDoc} */
   public function generateEndSessionEndpointRedirect(
       OidcTokens $tokens,
-      string $postLogoutRedirectUrl,
+      string $postLogoutRedirectUrl = null,
       array $additionalQueryParams = []
   ): RedirectResponse {
     $data = array_merge($additionalQueryParams, [
         'client_id'                => $this->clientId,
         'id_token_hint'            => $tokens->getIdToken(),
-        'post_logout_redirect_uri' => $postLogoutRedirectUrl,
     ]);
+
+    if (null !== $postLogoutRedirectUrl) {
+      $data = array_merge($data, [
+          'post_logout_redirect_uri' => $postLogoutRedirectUrl,
+      ]);
+    }
 
     $endpointHasQuery = parse_url($this->getEndSessionEndpoint(), PHP_URL_QUERY);
 

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -163,6 +163,23 @@ class OidcClient implements OidcClientInterface
   }
 
   /** {@inheritDoc} */
+  public function generateEndSessionEndpointRedirect(
+      OidcTokens $tokens,
+      string $postLogoutRedirectUrl,
+      array $additionalQueryParams = []
+  ): RedirectResponse {
+    $data = array_merge($additionalQueryParams, [
+        'client_id'                => $this->clientId,
+        'id_token_hint'            => $tokens->getIdToken(),
+        'post_logout_redirect_uri' => $postLogoutRedirectUrl,
+    ]);
+
+    $endpointHasQuery = parse_url($this->getEndSessionEndpoint(), PHP_URL_QUERY);
+
+    return new RedirectResponse(sprintf('%s%s%s', $this->getEndSessionEndpoint(), $endpointHasQuery ? '&' : '?', http_build_query($data)));
+  }
+
+  /** {@inheritDoc} */
   public function retrieveUserInfo(OidcTokens $tokens): OidcUserData
   {
     // Set the authorization header
@@ -190,6 +207,15 @@ class OidcClient implements OidcClientInterface
   protected function getAuthorizationEndpoint(): string
   {
     return $this->getConfigurationValue('authorization_endpoint');
+  }
+
+  /**
+   * @throws OidcConfigurationException
+   * @throws OidcConfigurationResolveException
+   */
+  protected function getEndSessionEndpoint(): string
+  {
+    return $this->getConfigurationValue('end_session_endpoint');
   }
 
   /**

--- a/src/OidcClientInterface.php
+++ b/src/OidcClientInterface.php
@@ -65,7 +65,7 @@ interface OidcClientInterface
    */
   public function generateEndSessionEndpointRedirect(
       OidcTokens $tokens,
-      string $postLogoutRedirectUrl,
+      ?string $postLogoutRedirectUrl,
       array $additionalQueryParams = [],
   ): RedirectResponse;
 

--- a/src/OidcClientInterface.php
+++ b/src/OidcClientInterface.php
@@ -54,6 +54,22 @@ interface OidcClientInterface
   ): RedirectResponse;
 
   /**
+   * Create the redirect that should be followed in order to end the current session.
+   *
+   * @param OidcTokens            $tokens                OidcTokens object containing the information to pass to the end_session endpoint
+   * @param string                $postLogoutRedirectUrl Contains the url where the provider redirects the user to after logging out
+   * @param array<string, string> $additionalQueryParams additional query parameters which will be added to the generated redirect request
+   *
+   * @throws OidcConfigurationException
+   * @throws OidcConfigurationResolveException
+   */
+  public function generateEndSessionEndpointRedirect(
+      OidcTokens $tokens,
+      string $postLogoutRedirectUrl,
+      array $additionalQueryParams = [],
+  ): RedirectResponse;
+
+  /**
    * Retrieve the user information.
    *
    * @throws OidcException

--- a/src/Security/Factory/OidcFactory.php
+++ b/src/Security/Factory/OidcFactory.php
@@ -63,18 +63,15 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
         ->addArgument($config['enable_remember_me']);
 
     $logoutListenerId = sprintf('security.logout.listener.default.%s', $firewallName);
-    $logoutTargetPath = null;
 
     // Check if "logout" config is specified in the firewall and "enable_end_session_listener" is set to true
     if ($config['enable_end_session_listener'] && $container->hasDefinition($logoutListenerId)) {
       $endSessionListenerId = sprintf('%s.%s', DrensoOidcExtension::END_SESSION_LISTENER_ID, $firewallName);
 
-      /**
-       * If "use_logout_target_path" is true (default) pass the target path to the {@see OidcEndSessionSubscriber}
-       */
-      if ($config['use_logout_target_path']) {
-        $logoutTargetPath = $container->getDefinition($logoutListenerId)->getArgument(1);
-      }
+      /** If "use_logout_target_path" is true (default) pass the target path to the {@see OidcEndSessionSubscriber} */
+      $logoutTargetPath = $config['use_logout_target_path']
+          ? $container->getDefinition($logoutListenerId)->getArgument(1)
+          : null;
 
       $container
           ->setDefinition($endSessionListenerId, new Definition(OidcEndSessionSubscriber::class))

--- a/src/Security/Factory/OidcFactory.php
+++ b/src/Security/Factory/OidcFactory.php
@@ -70,7 +70,7 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
       $endSessionListenerId = sprintf('%s.%s', DrensoOidcExtension::END_SESSION_LISTENER_ID, $firewallName);
 
       /**
-       * If "use_default_logout_target_path" is true (default) pass the target path to the {@see OidcEndSessionSubscriber}
+       * If "use_logout_target_path" is true (default) pass the target path to the {@see OidcEndSessionSubscriber}
        */
       if ($config['use_logout_target_path']) {
         $logoutTargetPath = $container->getDefinition($logoutListenerId)->getArgument(1);

--- a/src/Security/Factory/OidcFactory.php
+++ b/src/Security/Factory/OidcFactory.php
@@ -3,11 +3,13 @@
 namespace Drenso\OidcBundle\Security\Factory;
 
 use Drenso\OidcBundle\DependencyInjection\DrensoOidcExtension;
+use Drenso\OidcBundle\EventListener\OidcEndSessionSubscriber;
 use Drenso\OidcBundle\Security\Exception\UnsupportedManagerException;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AbstractFactory;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\AuthenticatorFactoryInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterface
@@ -24,6 +26,7 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
     $this->addOption('client', 'default');
     $this->addOption('user_identifier_property', 'sub');
     $this->addOption('enable_remember_me', false);
+    $this->addOption('enable_end_session_listener', false);
   }
 
   public function getPriority(): int
@@ -43,10 +46,12 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
       string $userProviderId): string
   {
     $authenticatorId = sprintf('%s.%s', DrensoOidcExtension::AUTHENTICATOR_ID, $firewallName);
+    $clientReference = new Reference(sprintf('%s.%s', DrensoOidcExtension::CLIENT_ID, $config['client']));
+
     $container
         ->setDefinition($authenticatorId, new ChildDefinition(DrensoOidcExtension::AUTHENTICATOR_ID))
         ->addArgument(new Reference('security.http_utils'))
-        ->addArgument(new Reference(sprintf('%s.%s', DrensoOidcExtension::CLIENT_ID, $config['client'])))
+        ->addArgument($clientReference)
         ->addArgument(new Reference(sprintf('%s.%s', DrensoOidcExtension::SESSION_STORAGE_ID, $config['client'])))
         ->addArgument(new Reference($userProviderId))
         ->addArgument(new Reference($this->createAuthenticationSuccessHandler($container, $firewallName, $config)))
@@ -55,6 +60,20 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
         ->addArgument($config['login_path'])
         ->addArgument($config['user_identifier_property'])
         ->addArgument($config['enable_remember_me']);
+
+    $logoutListenerId = sprintf('security.logout.listener.default.%s', $firewallName);
+
+    // Check if "logout" config is specified in the firewall and "enable_end_session_listener" is set to true
+    if ($config['enable_end_session_listener'] && $container->hasDefinition($logoutListenerId)) {
+      $endSessionListenerId = sprintf('%s.%s', DrensoOidcExtension::END_SESSION_LISTENER_ID, $firewallName);
+
+      $container->setDefinition($endSessionListenerId, new Definition(OidcEndSessionSubscriber::class))
+          ->addArgument($clientReference)
+          ->addArgument(new Reference('security.http_utils'))
+          ->addArgument($container->getDefinition($logoutListenerId)->getArgument(1)) // Get the configured logout target path
+          ->addTag('kernel.event_subscriber')
+        ;
+    }
 
     return $authenticatorId;
   }


### PR DESCRIPTION
This PR add support for the end_session_endpoint spec.

I chose to add the config to the listener and not the client (like we did with code challenge method), although the client supports it or not you might want to make a firewall specific setting for using it or not. For example, you might use the same client for a user login flow but also for an API implementation. In case of the API firewall you don't want to support a user flow logout.

```yaml
    firewalls:
        main:
            lazy: true
            pattern: ^/
            provider: user_provider
            logout: true
            oidc:
                enable_end_session_listener: true
```

The combination of `logout: true` and `enable_end_session_listener: true` will activate the event listener, which listens for the `onLogout`-event, it then uses the target path from the default Symfony logout listener to pass as the post_logout_redirect uri to the end_session_endpoint.