### PR TITLE
Adding support for getting the identifier from the id_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ There are a couple of options available for the `oidc` listener.
 | `login_path`                     | `/login`        | The path to forward to when authentication is required                                                                                        | 
 | `client`                         | `default`       | The configured OIDC client to use                                                                                                             |
 | `user_identifier_property`       | `sub`           | The OidcUserData property to use as unique user identifier                                                                                    |
+| `user_identifier_from_idtoken`   | `false`         | The identifier is fetched from the id_token instead of userinfo endpoint                                                                      |
 | `enable_remember_me`             | `false`         | Enable "remember me" functionality for authenticator                                                                                          |
 | `enable_end_session_listener`    | `false`         | Enable "logout" functionality for authenticator through the "LogoutEvent"                                                                     |
 | `use_logout_target_path`         | `true`          | Used for the end session event subscriber                                                                                                     |

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -442,7 +442,7 @@ class OidcClient implements OidcClientInterface
   private function verifyTokens(OidcTokens $tokens, $verifyNonce = true): OidcTokens
   {
     // Retrieve the claims
-    $claims = $this->jwtHelper->decodeJwt($tokens->getIdToken(), 1);
+    $claims = $this->jwtHelper->getIdTokenClaims($tokens);
 
     // Verify the token
     if (!$this->jwtHelper->verifyJwtSignature($this->getJwktUri(), $tokens)) {

--- a/src/OidcJwtHelper.php
+++ b/src/OidcJwtHelper.php
@@ -177,6 +177,11 @@ class OidcJwtHelper
     return $this->decodeJwt($tokens->getAccessToken(), 0);
   }
 
+  public function getIdTokenClaims(OidcTokens $tokens): ?object
+  {
+      return $this->decodeJwt($tokens->getIdToken(), 1);
+  }
+
   private function getKeyForHeader($keys, $header): object
   {
     foreach ($keys as $key) {

--- a/src/Security/Factory/OidcFactory.php
+++ b/src/Security/Factory/OidcFactory.php
@@ -25,6 +25,7 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
     // Set extra options
     $this->addOption('client', 'default');
     $this->addOption('user_identifier_property', 'sub');
+    $this->addOption('user_identifier_from_idtoken', false);
     $this->addOption('enable_remember_me', false);
     $this->addOption('enable_end_session_listener', false);
     $this->addOption('use_logout_target_path', true);
@@ -60,8 +61,10 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
         ->addArgument($config['check_path'])
         ->addArgument($config['login_path'])
         ->addArgument($config['user_identifier_property'])
-        ->addArgument($config['enable_remember_me']);
-
+        ->addArgument($config['enable_remember_me'])
+        ->addArgument($config['user_identifier_from_idtoken'])
+        ->addArgument(new Reference(sprintf("%s.%s", DrensoOidcExtension::JWT_HELPER_ID , $config['client'])))
+    ;
     $logoutListenerId = sprintf('security.logout.listener.default.%s', $firewallName);
 
     // Check if "logout" config is specified in the firewall and "enable_end_session_listener" is set to true


### PR DESCRIPTION
This PR: 
- adds support to fetch the user identifier from the idtoken instead of the userinfo endpoint.
- adds configuration parameter for controlling it with `user_identifier_from_idtoken`
- adds documentation for the feature 
- introduces a new `OidcJwtHelper->getIdTokenClaims()` method getIdTokenClaims() and use it in `verifyTokens`.

Not sure about: 
I use OidcClient to get the data from the token as it already had the token helper. 

For issue #37 