### PR TITLE
Also unset client-id parameter when doing basic auth

### DIFF
--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -411,6 +411,7 @@ class OidcClient implements OidcClientInterface
     $headers = [];
     if (in_array('client_secret_basic', $this->getTokenEndpointAuthMethods())) {
       $headers = ['Authorization: Basic ' . base64_encode(urlencode($this->clientId) . ':' . urlencode($this->clientSecret))];
+      unset($params['client_id']);
       unset($params['client_secret']);
     }
 


### PR DESCRIPTION
Since the client_id is already contained inside the Authorization Header, it is not really needed as an extra parameter anymore. Also this way you avoid any eventual inconsistencies between the 2 parameters.

And we actually encountered an Identity Provider that complained when that parameter was passed in addition to the Authorization Header for basic auth.