### PR TITLE
Allow psr/log 2.0 and 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-openssl": "*",
     "symfony/http-foundation": "^3.4.35 || ^4.2.12 || ^5.0.7",
     "symfony/routing": "^3.4 || ^4.0 || ^5.0",
-    "psr/log": "^1.1",
+    "psr/log": "^1.1 || ^2.0 || ^3.0",
     "phpseclib/phpseclib": "^2.0.31 || ^3.0.7",
     "symfony/dependency-injection": "^3.4.26 || ^4.1.12 || ^5.0",
     "symfony/security-bundle": "^3.4 || ^4.0 || ^5.0",


### PR DESCRIPTION
Unfortunately, I can't update to PHP 8.1 just yet, but I would like to use Symfony 5.4 and your OIDC bundle. This is not possible, as my other dependencies require psr/log 2.0 and symfony-oidc 1.x depends on 1.0.

There are no practical incompatibilities between the versions, so I hope you can release one more time for the 1.x branch with a change that allows more psr/log versions.

Many thanks in advance!