### PR TITLE
Add OidcTokens to OidcUserData

### DIFF
--- a/src/Model/OidcUserData.php
+++ b/src/Model/OidcUserData.php
@@ -10,11 +10,13 @@ class OidcUserData
 {
   private static ?PropertyAccessor $accessor = null;
   private stdClass $userData;
+  private OidcTokens $tokens;
 
-  public function __construct(array $userData)
+  public function __construct(array $userData, OidcTokens $tokens)
   {
     // Cast the array data to a stdClass for easy access
     $this->userData = (object)$userData;
+    $this->tokens = $tokens;
   }
 
   /** Get the OIDC sub claim */
@@ -104,5 +106,10 @@ class OidcUserData
 
     // Cast the user data to a stdClass
     return self::$accessor->getValue($this->userData, $propertyPath);
+  }
+
+  public function getTokens(): OidcTokens
+  {
+    return $this->tokens;
   }
 }

--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -226,7 +226,7 @@ class OidcClient implements OidcClientInterface
       throw new OidcException('Error retrieving the user info from the endpoint.');
     }
 
-    return new OidcUserData($data);
+    return new OidcUserData($data, $tokens);
   }
 
   /**


### PR DESCRIPTION
I am trying to migrate to Symfony OIDC 2 and it proves a little bit difficultbecause the new UserProvider methods do not have access to the auth / id tokens. In #35 it was mentioned that you would be open to a PR that adds data to the `OidcUserData` object. If this also includes the tokens, this PR adds that.

This does break BC if you count the constructor of `OidcUserData` as a public API. I could make some changes that would make the code less pretty but guarantee BC.