### PR TITLE
docs: add known usage to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,6 @@ Some providers return incorrect or incomplete well known information. You can co
 
 ## Known usages
 
-A list of Open source Projects that use this Symfony OIDC bundle:
+A list of open source projects that use this bundle:
 
 - Zitadel's [example-symfony-oidc](https://github.com/zitadel/example-symfony-oidc): A template repository with basic OIDC authentication, user model, roles and example pages.

--- a/README.md
+++ b/README.md
@@ -249,3 +249,9 @@ However, if you need to refresh the tokens yourself for your implementation, you
 ### Parsing well-known information
 
 Some providers return incorrect or incomplete well known information. You can configure a custom well-known parser for the `OidcClient` by setting the `well_known_parser` to a service id which implements the `OidcWellKnownParserInterface`.
+
+## Known usages
+
+A list of Open source Projects that use this Symfony OIDC bundle:
+
+- Zitadel's [example-symfony-oidc](https://github.com/zitadel/example-symfony-oidc): A template repository with basic OIDC authentication, user model, roles and example pages.


### PR DESCRIPTION
Adds zitadel's example implementation to the new known usage section.

Closes #46