### PR TITLE
update phpseclib to 2.0.47 and 3.0.36

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "ext-hash": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
-    "phpseclib/phpseclib": "^2.0.31 || ^3.0.7",
+    "phpseclib/phpseclib": "^2.0.47 || ^3.0.36",
     "psr/container": "^1.1 || ^2.0",
     "psr/log": "^1.1 || ^2.0 || ^3.0",
     "symfony/config": "^5.4 || ^6.3 || ^7.0",


### PR DESCRIPTION
phpsesclib contians the following security issues and needs to be pined to the versions ^2.0.47 and ^3.0.36.
fixes #51 