### PR TITLE
Add ability to specify additional token claim constraints

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,6 +29,9 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('well_known_parser')
                   ->defaultNull()
                 ->end() // well_known_parser
+                ->scalarNode('additional_token_constraints_provider')
+                  ->defaultNull()
+                ->end() // additional_token_constraints_provider
                 ->scalarNode('well_known_cache_time')
                   ->defaultValue(3600)
                   ->validate()

--- a/src/DependencyInjection/DrensoOidcExtension.php
+++ b/src/DependencyInjection/DrensoOidcExtension.php
@@ -58,13 +58,15 @@ class DrensoOidcExtension extends ConfigurableExtension
       ->addArgument($name);
 
     $jwtHelperId = sprintf('%s.%s', self::JWT_HELPER_ID, $name);
+    $additionalTokenConstraintsProviderId = $config['additional_token_constraints_provider'];
     $container
       ->setDefinition($jwtHelperId, new ChildDefinition(self::JWT_HELPER_ID))
       ->addArgument(new Reference($urlFetcherId))
       ->addArgument(new Reference($sessionStorageId))
       ->addArgument($config['client_id'])
       ->addArgument($config['jwks_cache_time'])
-      ->addArgument($config['token_leeway_seconds']);
+      ->addArgument($config['token_leeway_seconds'])
+      ->addArgument($additionalTokenConstraintsProviderId ? new Reference($additionalTokenConstraintsProviderId) : null);
 
     $clientId          = sprintf('%s.%s', self::CLIENT_ID, $name);
     $wellKnownParserId = $config['well_known_parser'];

--- a/src/OidcTokenConstraintProviderInterface.php
+++ b/src/OidcTokenConstraintProviderInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Drenso\OidcBundle;
+
+use Drenso\OidcBundle\Enum\OidcTokenType;
+use Lcobucci\JWT\Validation\Constraint;
+
+interface OidcTokenConstraintProviderInterface
+{
+  /**
+   * Provide additional Token constraints to be checked during Token validation
+   * @param OidcTokenType $tokenType
+   * @return Constraint[]
+   */
+  public function getAdditionalConstraints(OidcTokenType $tokenType): array;
+}


### PR DESCRIPTION
As a follow-up to https://github.com/Drenso/symfony-oidc/issues/58 : Just like @sebastianSchmidt86 I need to add further claim checks.

This PR adds an `OidcTokenConstraintProviderInterface` and a config key `additional_token_constraints_provider`. Developers can provide a class implementing the interface, and configure `drenso_oidc` to use it.

This functionality should not contain any breaking changes.

Example `drenso_oidc.yaml`:
```yaml
drenso_oidc:
    #default_client: default # The default client, will be aliased to OidcClientInterface
    clients:
        default: # The client name, each client will be aliased to its name (for example, $defaultOidcClient)
            # Required OIDC client configuration
            well_known_url: '%env(OIDC_WELL_KNOWN_URL)%'
            client_id: '%env(OIDC_CLIENT_ID)%'
            client_secret: '%env(OIDC_CLIENT_SECRET)%'

            additional_token_constraints_provider: App\Security\AdditionalTokenConstraintProvider
```

Example provider:
```php
<?php

namespace App\Security;

use App\Security\Constraint\HasAudienceContaining;
use Drenso\OidcBundle\Enum\OidcTokenType;
use Drenso\OidcBundle\OidcTokenConstraintProviderInterface;

class AdditionalTokenConstraintProvider implements OidcTokenConstraintProviderInterface
{
    public function getAdditionalConstraints(OidcTokenType $tokenType): array
    {
        if (OidcTokenType::ID === $tokenType) {
            return [
                new HasAudienceContaining('abc123'),
            ];
        }

        if (OidcTokenType::ACCESS === $tokenType) {
            return [
                new HasAudienceContaining('def456'),
            ];
        }

        return [];
    }
}
```