### PR TITLE
Do not send client_id when using basic authentication

### DIFF
--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -378,6 +378,7 @@ class OidcClient
     $headers = [];
     if (in_array('client_secret_basic', $this->getTokenEndpointAuthMethods())) {
       $headers = ['Authorization: Basic ' . base64_encode(urlencode($this->clientId) . ':' . urlencode($this->clientSecret))];
+      unset($params['client_id']);
       unset($params['client_secret']);
     }
 


### PR DESCRIPTION
Do not send client_id as a parameter when using basic authentication so Spring Security Framework accepts the request.
Spring Security Framework rejects requests when a client_id is sent as a parameter without a secret. If sent the framework completely ignores the credentials in basic authentication.