### PR TITLE
Add option to set user info from ID token

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ There are a couple of options available for the `oidc` listener.
 | `failure_forward`                | `false`         | Used for the failure handler                                                                                                                  |
 | `failure_path_parameter`         | `_failure_path` | Used for the failure handler                                                                                                                  |
 | `enable_retrieve_user_info`      | `true`          | Enable fetching data from the user info endpoint. *Required:* If disabled, `user_identifier_from_idtoken` must be set to `true`.              |
-| `user_info_from_idtoken`         | `true`          | The user info data is set from the ID token instead of fetching it from the endpoint.                                                         |
+| `user_info_from_idtoken`         | `false`         | The user info data is set from the ID token instead of fetching it from the endpoint.                                                         |
 
 You can configure them directly under the `oidc` listener in your firewall, for example the `user_identifier_property`:
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ There are a couple of options available for the `oidc` listener.
 | `failure_forward`                | `false`         | Used for the failure handler                                                                                                                  |
 | `failure_path_parameter`         | `_failure_path` | Used for the failure handler                                                                                                                  |
 | `enable_retrieve_user_info`      | `true`          | Enable fetching data from the user info endpoint. *Required:* If disabled, `user_identifier_from_idtoken` must be set to `true`.              |
+| `user_info_from_idtoken`         | `true`          | The user info data is set from the ID token instead of fetching it from the endpoint.                                                         |
 
 You can configure them directly under the `oidc` listener in your firewall, for example the `user_identifier_property`:
 

--- a/docs/ms-entra-id.md
+++ b/docs/ms-entra-id.md
@@ -19,11 +19,22 @@ Luckily, with some simple configuration you can solve this issue.
 1. According to the [Microsoft documentation](https://learn.microsoft.com/en-gb/entra/identity-platform/reference-app-manifest?WT.mc_id=Portal-Microsoft_AAD_RegisteredApps#accesstokenacceptedversion-attribute), you can set the `accessTokenAcceptedVersion` to `2` in the app manifest. It might take some time to propagate.
 2. If that doesn't work, you can configure a custom scope. See [this comment](https://github.com/Drenso/symfony-oidc/issues/62#issuecomment-2151759001) for some more details on how that can look. Make sure to add your custom scope to your `generateAuthorizationRedirect` call, so Entra ID is forced to generate a V2 token.
 
+> Be aware that this might leads to permission issues in combination with the V2 access token and fetching the user info from the Graph API endpoint.
+> See [Option 3](#option-3-use-the-id-token-to-fetch-user-data) for a possible solution.
+
 #### Option 2: Use V1 tokens
 
 > This is not the recommended solution, only use this if option 1 doesn't work for you!
 
 You can fully revert to the V1 tokens. This can be achieved by removing `/v2.0` from the well-known URL.
+
+#### Option 3: Use the ID token to fetch user data
+
+If you're facing issues when fetching the user info from the Graph API using the V2 access token from [Option 1](#option-1-fully-configure-v2-tokens):
+
+1. Disable `enable_retrieve_user_info`, enable `user_identifier_from_idtoken` and `user_info_from_idtoken`.
+2. Open the Entra ID admin center and [configure the additional claims](https://learn.microsoft.com/en-gb/entra/identity-platform/optional-claims) on your ID token.
+3. Add the `profile` scope to your `generateAuthorizationRedirect` call. 
 
 ### Future
 

--- a/src/Security/Factory/OidcFactory.php
+++ b/src/Security/Factory/OidcFactory.php
@@ -30,6 +30,7 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
     $this->addOption('enable_end_session_listener', false);
     $this->addOption('use_logout_target_path', true);
     $this->addOption('enable_retrieve_user_info', true);
+    $this->addOption('user_info_from_idtoken', false);
   }
 
   public function getPriority(): int
@@ -64,7 +65,8 @@ class OidcFactory extends AbstractFactory implements AuthenticatorFactoryInterfa
       ->addArgument($config['user_identifier_property'])
       ->addArgument($config['enable_remember_me'])
       ->addArgument($config['user_identifier_from_idtoken'])
-      ->addArgument($config['enable_retrieve_user_info']);
+      ->addArgument($config['enable_retrieve_user_info'])
+      ->addArgument($config['user_info_from_idtoken']);
 
     $logoutListenerId = sprintf('security.logout.listener.default.%s', $firewallName);
 

--- a/src/Security/OidcAuthenticator.php
+++ b/src/Security/OidcAuthenticator.php
@@ -12,6 +12,7 @@ use Drenso\OidcBundle\Security\Exception\OidcAuthenticationException;
 use Drenso\OidcBundle\Security\Exception\UnsupportedManagerException;
 use Drenso\OidcBundle\Security\Token\OidcToken;
 use Drenso\OidcBundle\Security\UserProvider\OidcUserProviderInterface;
+use Lcobucci\JWT\UnencryptedToken;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -90,6 +91,7 @@ class OidcAuthenticator implements InteractiveAuthenticatorInterface, Authentica
         }
 
         if ($this->userInfoFromIdToken) {
+          /** @var UnencryptedToken $idToken */
           $userData = new OidcUserData($idToken->claims()->all());
         } else {
           $userData = new OidcUserData([]);
@@ -98,6 +100,7 @@ class OidcAuthenticator implements InteractiveAuthenticatorInterface, Authentica
 
       // Look for the user identifier in either the id_token or the userinfo endpoint
       if ($this->userIdentifierFromIdToken) {
+        /** @var UnencryptedToken $idToken */
         $userIdentifier = $idToken->claims()->get($this->userIdentifierProperty);
       } else {
         $userIdentifier = $userData->getUserDataString($this->userIdentifierProperty);


### PR DESCRIPTION
This pull requests adds the ability to set the `OidcUserData` using the claims from the ID token. This mitigates [certain problems](https://github.com/Drenso/symfony-oidc/issues/62) in combination with Microsoft Entra ID and the v1 access token. Using the ID token instead of the user info endpoint is also one of the [recommended procedures by Microsoft](https://learn.microsoft.com/en-us/entra/identity-platform/userinfo#consider-using-an-id-token-instead).