### PR TITLE
fix: code verifier removes client secret, when secret is present

### DIFF
--- a/src/OidcClient.php
+++ b/src/OidcClient.php
@@ -522,8 +522,9 @@ class OidcClient implements OidcClientInterface
     }
 
     if ($codeVerifier = $this->sessionStorage->getCodeVerifier()) {
-      unset($params['client_secret']);
-
+      if (isset($params['client_secret']) && empty($params['client_secret'])) {
+        unset($params['client_secret']);
+      }
       $params = array_merge($params, [
         'code_verifier' => $codeVerifier,
       ]);


### PR DESCRIPTION
PKCE support ALLOWS you to work without a secret.
BUT it's safer to still work with confidential clients. So if the secret is not empty, we keep the secret.